### PR TITLE
improve output for check_github_usernames

### DIFF
--- a/github_user_management/check_github_users_in_ldap.py
+++ b/github_user_management/check_github_users_in_ldap.py
@@ -27,14 +27,14 @@ def check_github_usernames(github_token, ldap_url, ldap_base, github_url, org):
     gc = github_client.GithubClient(github_token, github_url)
 
     members = dict(
-        map(lambda x: (x.lower(), "github"), gc.get_members(org))
+        map(lambda x: (x.lower(), "only_in_github"), gc.get_members(org))
     )
 
     with ldap_client.LdapClient(ldap_url, ldap_base) as lc:
         for user, shell, github_user in lc.get_github_users():
             github_user = github_user.lower()
             if shell == '/dev/null':
-                if github_user in members:
+                if github_user in members and members[github_user] == 'only_in_github':
                     members[github_user] = 'github_user_that_quit'
                 continue
             if github_user not in members:
@@ -45,5 +45,5 @@ def check_github_usernames(github_token, ldap_url, ldap_base, github_url, org):
 
     print_dict_keys_per_value(
         members, ("matching", "to_add_to_github"),
-        ("github", "github_user_that_quit")
+        ("only_in_github", "github_user_that_quit")
     )


### PR DESCRIPTION
rename "github" to "only_in_github"
don't print users that were added to members list for to_add_to_github as github_user_that_quit if there are duplicate github usernames in LDAP. This happens when people enter things like "n/a" or '' for their github name in LDAP.