### PR TITLE
python3 and minor output improvements

### DIFF
--- a/github_user_management/add_ldap_users_to_employees.py
+++ b/github_user_management/add_ldap_users_to_employees.py
@@ -15,4 +15,4 @@ def check_github_usernames(github_token, ldap_url, ldap_base, github_url):
                 print ("ldap user %s doesn't have a valid github user: %s"
                        % (user, github_user))
             else:
-                print github_user
+                print (github_user)

--- a/github_user_management/check_github_users_in_ldap.py
+++ b/github_user_management/check_github_users_in_ldap.py
@@ -11,30 +11,30 @@ def print_dict_keys_per_value(d, exclude, check_existence_for_these):
     for k in d:
         by_value[d[k]].append(k)
     printed_categories = []
-    for v in sorted(by_value.iterkeys()):
+    for v in sorted(by_value.keys()):
         if v in exclude:
             continue
-        print v
+        print ("%s (%i)" % (v, len(by_value[v])))
         printed_categories.append(v)
         for k in sorted(by_value[v]):
-            print " " + k
+            print (" " + k)
     for cat in check_existence_for_these:
         if cat not in printed_categories:
-            print "Good news, category %s is empty!" % cat
+            print ("Good news, category %s is empty!" % cat)
 
 
 def check_github_usernames(github_token, ldap_url, ldap_base, github_url, org):
     gc = github_client.GithubClient(github_token, github_url)
 
     members = dict(
-        map(lambda x: (x.lower(), "github"), gc.get_members(org))
+        map(lambda x: (x.lower(), "only_in_github"), gc.get_members(org))
     )
 
     with ldap_client.LdapClient(ldap_url, ldap_base) as lc:
         for user, shell, github_user in lc.get_github_users():
-            github_user = github_user.lower()
-            if shell == '/dev/null':
-                if github_user in members:
+            github_user = github_user.lower().decode('UTF-8')
+            if shell.decode('UTF-8') == '/dev/null':
+                if github_user in members and members[github_user] == 'only_in_github':
                     members[github_user] = 'github_user_that_quit'
                 continue
             if github_user not in members:
@@ -45,5 +45,5 @@ def check_github_usernames(github_token, ldap_url, ldap_base, github_url, org):
 
     print_dict_keys_per_value(
         members, ("matching", "to_add_to_github"),
-        ("github", "github_user_that_quit")
+        ("only_in_github", "github_user_that_quit")
     )

--- a/github_user_management/get_keys_for_org.py
+++ b/github_user_management/get_keys_for_org.py
@@ -8,4 +8,4 @@ def main(github_token, github_url, org):
             github_token, github_url, org):
         with open("keys/%s-%s" % (member, id), 'w') as f:
             f.write(key)
-            print member
+            print (member)

--- a/github_user_management/github_details_for_users.py
+++ b/github_user_management/github_details_for_users.py
@@ -11,6 +11,6 @@ def print_details_for_users(users_filename, token, github_url):
             user = gc.get_user(u)
             email = user["email"]
             if email:
-                print "Email for %s is %s" % (u, email)
+                print ("Email for %s is %s" % (u, email))
             else:
-                print "no email for user " + u
+                print ("no email for user " + u)

--- a/github_user_management/org_owners_without_ldap_connection.py
+++ b/github_user_management/org_owners_without_ldap_connection.py
@@ -17,12 +17,12 @@ def print_email_if_available(github_members, ldap_url, ldap_base, domain):
             else:
                 missing_ldap_mappings.append(user)
 
-    print "there are %d users" % len(users)
-    print ", ".join(users)
+    print ("there are %d users" % len(users))
+    print (", ".join(users))
 
     if missing_ldap_mappings:
-        print "\nDrop these users from the team (they lack LDAP mapping)"
+        print ("\nDrop these users from the team (they lack LDAP mapping)")
         for user in missing_ldap_mappings:
-            print user
+            print (user)
     else:
-        print "\nNo users lacking LDAP mapping. Yay!"
+        print ("\nNo users lacking LDAP mapping. Yay!")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.20.0
-python-ldap==2.4.27
-click==6.6
+python-ldap==3.3.0
+click==8.0.3
 # from requests[security]
 cryptography==3.2
 ndg-httpsclient==0.4.2


### PR DESCRIPTION
fix print statements to work with Python3
replace .iterkeys() with .keys for Python3
rename "github" to "only_in_github"
don't print users that were added to members list for to_add_to_github as github_user_that_quit if there are duplicate github usernames in LDAP. This happens when people enter things like "n/a" or '' for their github name in LDAP.